### PR TITLE
ipam-subnet-nsg-logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ resource "azurerm_network_security_rule" "custom_rules_for" {
   destination_application_security_group_ids = lookup(each.value, "destination_application_security_group_ids", null)
   destination_port_range                     = lookup(each.value, "destination_port_range", null)
   destination_port_ranges                    = lookup(each.value, "destination_port_ranges", null)
-  source_address_prefix                      = lookup(each.value, "source_application_security_group_ids", null) == null && lookup(each.value, "source_address_prefixes", null) == null ? lookup(each.value, "source_address_prefix", "*") : null
+  source_address_prefix                      = lookup(each.value, "source_application_security_group_ids", null) == null && lookup(each.value, "source_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "source_address_prefix", null), null) != null ? lookup(var.subnets, lookup(each.value, "source_address_prefix")) : lookup(each.value, "source_address_prefix", "*")) : null
   source_address_prefixes                    = lookup(each.value, "source_application_security_group_ids", null) == null ? lookup(each.value, "source_address_prefixes", null) : null
   source_application_security_group_ids      = lookup(each.value, "source_application_security_group_ids", null)
   source_port_range                          = lookup(each.value, "source_port_range", "*") == "*" ? "*" : null

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "azurerm_network_security_rule" "custom_rules_for" {
   protocol                                   = lookup(each.value, "protocol", "*")
   resource_group_name                        = var.resource_group_name
   description                                = lookup(each.value, "description", "Security rule for ${lookup(each.value, "name", "default_rule_name")}")
-  destination_address_prefix                 = lookup(each.value, "destination_application_security_group_ids", null) == null && lookup(each.value, "destination_address_prefixes", null) == null ? lookup(each.value, "destination_address_prefix", "*") : null
+  destination_address_prefix                 = lookup(each.value, "destination_application_security_group_ids", null) == null && lookup(each.value, "destination_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "destination_address_prefix", null), null) != null ? lookup(var.subnets, lookup(each.value, "destination_address_prefix")) : lookup(each.value, "destination_address_prefix", "*")) : null
   destination_address_prefixes               = lookup(each.value, "destination_application_security_group_ids", null) == null ? lookup(each.value, "destination_address_prefixes", null) : null
   destination_application_security_group_ids = lookup(each.value, "destination_application_security_group_ids", null)
   destination_port_range                     = lookup(each.value, "destination_port_range", null)

--- a/main.tf
+++ b/main.tf
@@ -63,12 +63,12 @@ resource "azurerm_network_security_rule" "custom_rules_for" {
   protocol                                   = lookup(each.value, "protocol", "*")
   resource_group_name                        = var.resource_group_name
   description                                = lookup(each.value, "description", "Security rule for ${lookup(each.value, "name", "default_rule_name")}")
-  destination_address_prefix                 = lookup(each.value, "destination_application_security_group_ids", null) == null && lookup(each.value, "destination_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "destination_address_prefix", null), null) != null ? lookup(var.subnets, lookup(each.value, "destination_address_prefix")) : lookup(each.value, "destination_address_prefix", "*")) : null
+  destination_address_prefix                 = lookup(each.value, "destination_application_security_group_ids", null) == null && lookup(each.value, "destination_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "destination_address_prefix", null), null) != null ? lookup(var.subnets, lookup(each.value, "destination_address_prefix", null)) : lookup(each.value, "destination_address_prefix", "*")) : null
   destination_address_prefixes               = lookup(each.value, "destination_application_security_group_ids", null) == null ? lookup(each.value, "destination_address_prefixes", null) : null
   destination_application_security_group_ids = lookup(each.value, "destination_application_security_group_ids", null)
   destination_port_range                     = lookup(each.value, "destination_port_range", null)
   destination_port_ranges                    = lookup(each.value, "destination_port_ranges", null)
-  source_address_prefix                      = lookup(each.value, "source_application_security_group_ids", null) == null && lookup(each.value, "source_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "source_address_prefix", null), null) != null ? lookup(var.subnets, lookup(each.value, "source_address_prefix")) : lookup(each.value, "source_address_prefix", "*")) : null
+  source_address_prefix                      = lookup(each.value, "source_application_security_group_ids", null) == null && lookup(each.value, "source_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "source_address_prefix", null), null) != null ? lookup(var.subnets, lookup(each.value, "source_address_prefix", null)) : lookup(each.value, "source_address_prefix", "*")) : null
   source_address_prefixes                    = lookup(each.value, "source_application_security_group_ids", null) == null ? lookup(each.value, "source_address_prefixes", null) : null
   source_application_security_group_ids      = lookup(each.value, "source_application_security_group_ids", null)
   source_port_range                          = lookup(each.value, "source_port_range", "*") == "*" ? "*" : null

--- a/main.tf
+++ b/main.tf
@@ -63,12 +63,12 @@ resource "azurerm_network_security_rule" "custom_rules_for" {
   protocol                                   = lookup(each.value, "protocol", "*")
   resource_group_name                        = var.resource_group_name
   description                                = lookup(each.value, "description", "Security rule for ${lookup(each.value, "name", "default_rule_name")}")
-  destination_address_prefix                 = lookup(each.value, "destination_application_security_group_ids", null) == null && lookup(each.value, "destination_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "destination_address_prefix", null), null) != null ? lookup(var.subnets, lookup(each.value, "destination_address_prefix", null)) : lookup(each.value, "destination_address_prefix", "*")) : null
+  destination_address_prefix                 = lookup(each.value, "destination_application_security_group_ids", null) == null && lookup(each.value, "destination_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "destination_address_prefix", ""), null) != null ? lookup(var.subnets, lookup(each.value, "destination_address_prefix", "")) : lookup(each.value, "destination_address_prefix", "*")) : null
   destination_address_prefixes               = lookup(each.value, "destination_application_security_group_ids", null) == null ? lookup(each.value, "destination_address_prefixes", null) : null
   destination_application_security_group_ids = lookup(each.value, "destination_application_security_group_ids", null)
   destination_port_range                     = lookup(each.value, "destination_port_range", null)
   destination_port_ranges                    = lookup(each.value, "destination_port_ranges", null)
-  source_address_prefix                      = lookup(each.value, "source_application_security_group_ids", null) == null && lookup(each.value, "source_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "source_address_prefix", null), null) != null ? lookup(var.subnets, lookup(each.value, "source_address_prefix", null)) : lookup(each.value, "source_address_prefix", "*")) : null
+  source_address_prefix                      = lookup(each.value, "source_application_security_group_ids", null) == null && lookup(each.value, "source_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "source_address_prefix", ""), null) != null ? lookup(var.subnets, lookup(each.value, "source_address_prefix", "")) : lookup(each.value, "source_address_prefix", "*")) : null
   source_address_prefixes                    = lookup(each.value, "source_application_security_group_ids", null) == null ? lookup(each.value, "source_address_prefixes", null) : null
   source_application_security_group_ids      = lookup(each.value, "source_application_security_group_ids", null)
   source_port_range                          = lookup(each.value, "source_port_range", "*") == "*" ? "*" : null

--- a/main.tf
+++ b/main.tf
@@ -63,12 +63,12 @@ resource "azurerm_network_security_rule" "custom_rules_for" {
   protocol                                   = lookup(each.value, "protocol", "*")
   resource_group_name                        = var.resource_group_name
   description                                = lookup(each.value, "description", "Security rule for ${lookup(each.value, "name", "default_rule_name")}")
-  destination_address_prefix                 = lookup(each.value, "destination_application_security_group_ids", null) == null && lookup(each.value, "destination_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "destination_address_prefix", ""), null) != null ? lookup(var.subnets, lookup(each.value, "destination_address_prefix", "")) : lookup(each.value, "destination_address_prefix", "*")) : null
+  destination_address_prefix                 = lookup(each.value, "destination_application_security_group_ids", null) == null && lookup(each.value, "destination_address_prefixes", null) == null ? (lookup(var.subnets, try(each.value.destination_address_prefix, ""), null) != null ? lookup(var.subnets, try(each.value.destination_address_prefix, "")) : try(each.value.destination_address_prefix, "*")) : null
   destination_address_prefixes               = lookup(each.value, "destination_application_security_group_ids", null) == null ? lookup(each.value, "destination_address_prefixes", null) : null
   destination_application_security_group_ids = lookup(each.value, "destination_application_security_group_ids", null)
   destination_port_range                     = lookup(each.value, "destination_port_range", null)
   destination_port_ranges                    = lookup(each.value, "destination_port_ranges", null)
-  source_address_prefix                      = lookup(each.value, "source_application_security_group_ids", null) == null && lookup(each.value, "source_address_prefixes", null) == null ? (lookup(var.subnets, lookup(each.value, "source_address_prefix", ""), null) != null ? lookup(var.subnets, lookup(each.value, "source_address_prefix", "")) : lookup(each.value, "source_address_prefix", "*")) : null
+  source_address_prefix                      = lookup(each.value, "source_application_security_group_ids", null) == null && lookup(each.value, "source_address_prefixes", null) == null ? (lookup(var.subnets, try(each.value.source_address_prefix, ""), null) != null ? lookup(var.subnets, try(each.value.source_address_prefix, "")) : try(each.value.source_address_prefix, "*")) : null
   source_address_prefixes                    = lookup(each.value, "source_application_security_group_ids", null) == null ? lookup(each.value, "source_address_prefixes", null) : null
   source_application_security_group_ids      = lookup(each.value, "source_application_security_group_ids", null)
   source_port_range                          = lookup(each.value, "source_port_range", "*") == "*" ? "*" : null

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,9 @@ variable "disable_microsegmentation" {
   default     = false
   description = "Disable microsegmentation between subnets? Should only be used if necessary. Defaults to false."
 }
+
+variable "subnets" {
+  description = "A map of subnet names to CIDR ranges in the virtual network, for use in NSG rules"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
Accept map var.subnets which can be used in NSG rules to specify (key) name of source/destination subnet instead of IP range directly. This allows for a more flexible setup that works well with IPAM.
```
